### PR TITLE
Add popular articles feed endpoint, integration tests, and GitHub Actions CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,35 +1,51 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+# Build and test on every push/PR to master.
+# Matrix: JDK 17 and 21. Gradle deps cached via gradle-build-action.
+# JUnit XML published as GitHub check annotations via dorny/test-reporter.
 
 name: CI with Gradle
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [master]
   pull_request:
-    branches: [ "master" ]
+    branches: [master]
 
 permissions:
   contents: read
+  checks: write
 
 jobs:
-  build:
-
+  build-and-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [17, 21]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK
-      uses: actions/setup-java@v3
-      with:
-        java-version: '16'
-        distribution: temurin
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-    
-    - name: Execute Gradle build
-      run: ./gradlew build
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v3
+
+      - name: Build
+        run: ./gradlew build --no-daemon
+
+      - name: Test
+        run: ./gradlew test --no-daemon
+
+      - name: Publish JUnit test report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: JUnit Tests (JDK ${{ matrix.java-version }})
+          path: build/test-results/test/*.xml
+          reporter: java-junit
+          fail-on-error: true

--- a/.github/workflows/spec-api.yml
+++ b/.github/workflows/spec-api.yml
@@ -1,0 +1,66 @@
+# Bonus: run RealWorld Postman collection (newman) against a locally started server.
+# This app serves routes without an /api prefix, so APIURL is http://localhost:8080.
+# Many endpoints are still stubs — job is informational (continue-on-error) until fully implemented.
+
+name: RealWorld API Spec Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  spec-api:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v3
+
+      - name: Build application
+        run: ./gradlew build --no-daemon
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Start server
+        run: |
+          ./gradlew run --no-daemon > server.log 2>&1 &
+          echo $! > server.pid
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8080/tags > /dev/null; then
+              echo "Server ready on port 8080"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Server failed to start"
+          cat server.log
+          exit 1
+
+      - name: Run RealWorld API spec tests
+        run: |
+          chmod +x spec-api/run-api-tests.sh
+          APIURL=http://localhost:8080 spec-api/run-api-tests.sh
+
+      - name: Stop server
+        if: always()
+        run: |
+          if [ -f server.pid ]; then
+            kill "$(cat server.pid)" 2>/dev/null || true
+          fi
+          ./gradlew --stop || true

--- a/PLAN.md
+++ b/PLAN.md
@@ -19,9 +19,11 @@ This is a [RealWorld](https://github.com/gothinkster/realworld) spec implementat
 z
 ### Quick Start
 ```bashz
-./gradlew clean build   # Build
-./gradlew run           # Start server on port 8080
-./gradlew test          # Run tests
+./gradlew --stop           # stop existing gradle daemons running
+rm -fR ~/.gradle/caches/*  # make sure caches are clean
+./gradlew clean build      # Build
+./gradlew run              # Start server on port 8080
+./gradlew test             # Run tests
 ```
 
 ---

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,134 @@
+# FDE Candidate Technical Exercise
+
+## Overview
+
+This exercise evaluates your ability to work with an existing codebase, add meaningful features, write tests using AI-powered tooling, and set up CI/CD — skills central to the Field Developer Engineer role.
+
+**Time Budget:** ~90 minutes  
+**Repository:** [Rudge/kotlin-ktor-realworld-example-app](https://github.com/Rudge/kotlin-ktor-realworld-example-app)
+
+---
+
+## Background
+
+This is a [RealWorld](https://github.com/gothinkster/realworld) spec implementation using **Kotlin + Ktor + Exposed + H2**. It demonstrates CRUD, authentication (JWT), routing, and pagination for a Medium-like blogging platform.
+
+### Tech Stack
+- Kotlin, Ktor (web framework), Kodein (DI), Exposed (SQL ORM), H2 (in-memory DB)
+- Existing tests use JUnit + Unirest (HTTP client)
+z
+### Quick Start
+```bashz
+./gradlew clean build   # Build
+./gradlew run           # Start server on port 8080
+./gradlew test          # Run tests
+```
+
+---
+
+## Instructions
+
+### Part 1: Fork & Setup
+
+1. Fork this repository to your personal GitHub account.
+2. Clone your fork locally and verify the project builds (`./gradlew clean build`).
+3. Create a feature branch (e.g., `feature/article-favorites-count`).
+
+---
+
+### Part 2: Add a Feature
+
+Implement **one** of the following features (or propose your own of similar scope):
+
+#### Option A: Article Favorites Count Endpoint
+Add a `GET /api/articles/feed/popular` endpoint that returns articles sorted by number of favorites (most favorited first). Include pagination support (`limit` and `offset` query params).
+
+#### Option B: User Activity Stats
+Add a `GET /api/profiles/:username/stats` endpoint that returns:
+```json
+{
+  "stats": {
+    "articlesCount": 5,
+    "commentsCount": 12,
+    "favoritesCount": 3
+  }
+}
+```
+
+#### Option C: Article Search
+Add a `GET /api/articles/search?q=<term>` endpoint that searches articles by title and body content. Return results in the standard article list format.
+
+**Requirements:**
+- Follow the existing code patterns (controller → service → repository layers).
+- Ensure the feature requires authentication where appropriate.
+- Handle error cases (404, 401, 422) consistently with existing error handling.
+
+---
+
+### Part 3: Write Tests Using Copilot Agent Harness
+
+Use the **GitHub Copilot coding agent** (via GitHub Issue or Copilot Chat in your IDE) to generate and iterate on tests for your new feature.
+
+**What we want to see:**
+
+1. **Create an issue** in your forked repo describing the tests needed for your feature. Assign it to Copilot (or use `@copilot` in the issue body) to generate a PR with tests.
+2. **Review the agent's output** — refine the generated tests, fix any issues, and ensure they:
+   - Cover the happy path (valid request → expected response).
+   - Cover at least 2 error cases (e.g., unauthenticated, not found, invalid input).
+   - Follow the existing test style in `src/test/kotlin/io/realworld/app/web/controllers/`.
+3. **Document your experience** — In your PR description, briefly note:
+   - What prompt(s) you gave the agent.
+   - What worked well vs. what you had to fix manually.
+   - How you'd improve the agent workflow for a customer.
+
+---
+
+### Part 4: GitHub Actions CI/CD
+
+Update the CI pipeline (`.github/workflows/`) to include:
+
+1. **Build & Test** — Run `./gradlew build` and `./gradlew test` on every push and PR to `main`/`master`.
+2. **Multi-JDK Matrix** — Test against JDK 17 and JDK 21.
+3. **Test Reporting** — Publish JUnit test results as a check annotation (use an action like `dorny/test-reporter` or `mikepenz/action-junit-report`).
+4. **Caching** — Ensure Gradle dependencies are cached between runs.
+5. **(Bonus)** Add a workflow that runs the RealWorld API spec tests (`spec-api/run-api-tests.sh`) against the running server.
+
+---
+
+## Deliverables
+
+Submit a **single Pull Request** to your fork's `main` branch containing:
+
+- [ ] The new feature implementation (Part 2)
+- [ ] Tests generated/refined with the Copilot agent (Part 3)
+- [ ] Updated GitHub Actions workflow(s) (Part 4)
+- [ ] A clear PR description covering your approach, decisions, and agent experience
+
+---
+
+## Evaluation Criteria
+
+| Area | What We're Looking For |
+|------|----------------------|
+| **Code Quality** | Clean, idiomatic Kotlin. Follows existing patterns. Proper error handling. |
+| **Testing** | Meaningful coverage. Tests actually pass. Good assertions. |
+| **Agent Fluency** | Effective use of Copilot agent. Thoughtful critique of its output. Clear documentation of prompts and iteration. |
+| **CI/CD** | Working pipeline. Correct matrix setup. Good use of caching and reporting. |
+| **Communication** | Clear PR description. Good commit messages. Explains trade-offs. |
+
+---
+
+## Tips
+
+- The existing test infrastructure in `src/test/kotlin/.../rules/AppRule.kt` boots the full app for integration testing — use this pattern.
+- Look at `UserControllerTest.kt` for a good example of the testing style.
+- The H2 database is in-memory and resets between test runs — no external DB setup needed.
+- If you get stuck on the build, JDK 16+ is required (the project uses `jvmTarget = "16"`).
+
+---
+
+## Questions?
+
+If anything is unclear, reach out to your interviewer. Part of this exercise is about how you communicate and unblock yourself — don't hesitate to ask.
+
+Good luck! 🚀

--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ Start the server:
 
 In the project have the [spec-api](https://github.com/Rudge/kotlin-ktor-realworld-example-app/tree/master/spec-api) with the README and collections to execute backend tests specs [realworld](https://github.com/gothinkster/realworld).
 
-Execute tests and start the server:
-
-> ./gradlew run & APIURL=http://localhost:8080 ./spec-api/run-api-tests.sh
+For CI workflow details and how to run spec-api tests locally, see [testing.md](testing.md).
 
 # Help
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,21 +3,19 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext {
-        kotlin_version = "1.3.+"
+        kotlin_version = "1.9.24"
         slf4j_version = "2.0.9"
-        ktor_version = "1.2.3"
-        kodein_version = "6.1.0"
+        ktor_version = "1.6.8"
+        kodein_version = "6.5.5"
         hikaricp_version = "5.1.0"
-        h2_version = "2.2.224"
-        exposed_version = "0.14.1"
+        h2_version = "1.4.200"
+        exposed_version = "0.17.14"
         junit_version = "4.13.2"
         unirest_version = "1.4.9"
     }
 
     repositories {
-        mavenLocal()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -26,12 +24,18 @@ buildscript {
 
 apply plugin: 'kotlin'
 apply plugin: 'application'
-mainClassName = "io.realworld.app.AppKt"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+application {
+    mainClass = "io.realworld.app.AppKt"
+}
 
 repositories {
-    mavenLocal()
     mavenCentral()
-    jcenter()
 }
 
 dependencies {
@@ -46,6 +50,16 @@ dependencies {
     api "com.h2database:h2:$h2_version"
     api "org.jetbrains.exposed:exposed:$exposed_version"
 
-    testCompile "junit:junit:$junit_version"
-    testCompile "com.mashape.unirest:unirest-java:$unirest_version"
+    testImplementation "junit:junit:$junit_version"
+    testImplementation "com.mashape.unirest:unirest-java:$unirest_version"
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        jvmTarget = "17"
+        freeCompilerArgs += [
+            "-opt-in=io.ktor.utils.io.KtorExperimentalAPI",
+            "-opt-in=io.ktor.server.engine.EngineAPI"
+        ]
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Wed Mar 27 00:54:28 BRT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip

--- a/local-development-environment.md
+++ b/local-development-environment.md
@@ -1,0 +1,139 @@
+# Local Development Environment
+
+How to set up and run this project on your machine.
+
+## Requirements
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| **JDK** | 21 | Used to run Gradle and compile the project (JVM target 17) |
+| **Gradle** | 8.5 (via wrapper) | Always use `./gradlew` from the project root |
+
+---
+
+## Nix shell (recommended)
+
+The repo includes [`shell.nix`](shell.nix), which provides JDK 21 and sets `JAVA_HOME` for you.
+
+### Install Nix
+
+`nix-shell` is included with the [Nix package manager](https://nixos.org/download/).
+
+**Linux (multi-user install):**
+
+```bash
+sh <(curl -L https://nixos.org/nix/install) --daemon
+```
+
+Follow the prompts, then open a new terminal (or `source` the profile snippet the installer prints).
+
+**Verify:**
+
+```bash
+nix --version
+```
+
+### Enter the development shell
+
+From the project root:
+
+```bash
+cd kotlin-ktor-realworld-example-app
+nix-shell
+```
+
+On first run, Nix downloads Azul Zulu JDK 21. You should see:
+
+```
+java 21, vim and zellij are now available
+JAVA_HOME=/nix/store/...-zulu-ca-jdk-21...
+```
+
+### Verify Java
+
+```bash
+echo $JAVA_HOME
+java -version
+```
+
+Both should reference JDK 21.
+
+### Build and run
+
+```bash
+./gradlew clean build    # compile and run tests
+./gradlew run            # start the API server on port 8080
+```
+
+Install the app distribution locally (optional):
+
+```bash
+./gradlew clean install  # output under build/install/api/
+```
+
+Run RealWorld API spec tests (server must be running):
+
+```bash
+./gradlew run &
+APIURL=http://localhost:8080 ./spec-api/run-api-tests.sh
+```
+
+Leave the shell with `exit`.
+
+---
+
+## Manual JDK setup (without Nix)
+
+Install **JDK 21** (e.g. [Azul Zulu 21](https://www.azul.com/downloads/?package=jdk#zulu) or Eclipse Temurin 21), then:
+
+```bash
+export JAVA_HOME=/path/to/jdk-21
+export PATH="$JAVA_HOME/bin:$PATH"
+
+java -version
+./gradlew clean build
+./gradlew run
+```
+
+---
+
+## `JAVA_HOME`
+
+`./gradlew` uses **`JAVA_HOME` before `PATH`** when choosing a JVM:
+
+1. If `JAVA_HOME` is set → `$JAVA_HOME/bin/java`
+2. Otherwise → `java` from `PATH`
+
+Because of that, `java -version` and `./gradlew` can use different JDKs if `JAVA_HOME` points somewhere else (IDE, shell profile, etc.).
+
+**In nix-shell**, `shell.nix` sets both consistently:
+
+```bash
+export JAVA_HOME="${pkgs.zulu21}"
+export PATH="$JAVA_HOME/bin:$PATH"
+```
+
+**Without nix-shell**, set `JAVA_HOME` yourself before running Gradle.
+
+If you change JDK versions, stop existing Gradle daemons so they pick up the new Java:
+
+```bash
+./gradlew --stop
+./gradlew clean build
+```
+
+---
+
+## Quick reference
+
+| Task | Command |
+|------|---------|
+| Enter dev environment | `nix-shell` |
+| Check Java | `echo $JAVA_HOME && java -version` |
+| Clean build + tests | `./gradlew clean build` |
+| Run server | `./gradlew run` |
+| Install distribution | `./gradlew clean install` |
+| Stop Gradle daemons | `./gradlew --stop` |
+| API spec tests | `./gradlew run &` then `APIURL=http://localhost:8080 ./spec-api/run-api-tests.sh` |
+
+Server URL: [http://localhost:8080](http://localhost:8080)

--- a/prompts-history.md
+++ b/prompts-history.md
@@ -106,3 +106,19 @@ why in the world are we introducing timing directives?
 
 what's with dynamic ports, how come what we had before was not sufficient?
 @AppRule.kt (13-20) 
+
+2026-06-30 18:02:08-04:00
+
+take all staged files. create comments for each file changed and why we are changing things inside each file.
+let me preview the  git commit message.
+and only local commit (dont push nothing to remote)
+
+2026-06-30 18:04:08-04:00
+let's implement Part4:@PLAN.md (87-88) 
+
+2026-06-30 18:12:08-04:00
+don't need to add "main" branch for ci. did not have before.
+update README.md to include link to `testing.md` which should include docs for gradle.yaml overview, local run notes for @.github/workflows/spec-api.yml 
+
+2026-06-30 18:20:08-04:00
+@run-api-tests.sh (5-6)  what's with this site? its not a real url. can we just remove the default cloud url, and just error out if nothing is passed in. show usage too, this way can instruct that cloud url pointing is possible. show example url. 

--- a/prompts-history.md
+++ b/prompts-history.md
@@ -1,35 +1,56 @@
-2026-06-30 15:36:08-04:00
-@README.md . gradlew clean install is failing. figure out what's wrong.
+# Prompt history
 
-Latest JDK25 is too new, using JDK21
+Chronological log of prompts used during this assessment.
 
-2026-06-30 15:43:08-04:00
-you see my terminal output when I try to run ./gradlew clean install ?
+---
 
-extra:
-first run outside 
+**2026-06-30 15:36**
 
-2026-06-30 15:52:08-04:00
-nope. build fails for both `gradlew clean install` and `gradlew clean build`
+`./gradlew clean install` is failing — diagnose and fix. Context: JDK 25 is too new; use JDK 21.
 
-2026-06-30 16:01:08-04:00
-create local-development-environment.md with how to run the project cleanly, including nix-shell . how to install nix-shell and commands to run after.
+---
 
-document JAVA_HOME environment variable details.
+**2026-06-30 15:43**
 
-2026-06-30 16:05:08-04:00
-update @local-development-environment.md  . dont need to mention JDK25 , that was just a starting point. we are just documenting how to run the project now. never mind previous shell.nix
+Review terminal output from `./gradlew clean install`. Note: first run was attempted outside nix-shell.
 
-2026-06-30 16:13:08-04:00
-check out my terminal , ./gradlew run shows a stacktrace with errors. port 8080 does not start listenning . some server is not standing up. there should be no external services requirements.
+---
 
-2026-06-30 16:20:08-04:00
-you test yourself. and access endpoint that works. hit existing restful endpoint to create one entity and retrieve it back. i want a working server.
+**2026-06-30 15:52**
 
-2026-06-30 16:29:08-04:00
+Build still fails for both `./gradlew clean install` and `./gradlew clean build`.
 
-bellow now works
+---
 
+**2026-06-30 16:01**
+
+Create `local-development-environment.md`: how to run the project cleanly with `nix-shell`, how to install Nix, post-setup commands, and `JAVA_HOME` details.
+
+---
+
+**2026-06-30 16:05**
+
+Update `local-development-environment.md` — drop JDK 25 troubleshooting; document current setup only. Do not dwell on earlier `shell.nix` history.
+
+---
+
+**2026-06-30 16:13**
+
+`./gradlew run` throws a stack trace; nothing listens on port 8080. The server should start with no external service dependencies.
+
+---
+
+**2026-06-30 16:20**
+
+Verify yourself: hit a working REST endpoint — create an entity and read it back. Goal is a working server.
+
+---
+
+**2026-06-30 16:29**
+
+Confirmed working flow:
+
+```bash
 # 1. Create user
 curl -X POST http://localhost:8080/users \
   -H "Content-Type: application/json" \
@@ -38,87 +59,76 @@ curl -X POST http://localhost:8080/users \
 # 2. Retrieve user (use token from step 1)
 curl http://localhost:8080/user \
   -H "Authorization: Token <token>"
+```
 
-2026-06-30 16:41:08-04:00
-@src/main/kotlin/io/realworld/app/domain/User.kt ln: 11 . before UserDTO required empty password , and now we are not allowing blank password? before userdto was creating random password / username ? obvious bug . or logic oversight ?
+---
 
-Answer:
-Most likely cause
+**2026-06-30 16:41**
 
-A missing ! — the intended checks were almost certainly:
+`User.kt` line 11: did `UserDTO` previously require an empty password, and now blank passwords are rejected? Was it generating random username/password before — bug or intentional?
 
-!user.password.isNullOrBlank() &&
-!user.username.isNullOrBlank()
-Same pattern was wrong in validLogin() and validToUpdate(). Tests didn’t catch it because UserControllerTest is marked @Ignore.
+**Outcome:** Inverted `isNullOrBlank()` checks (missing `!`) in `validRegister()`, `validLogin()`, and `validToUpdate()`. Tests missed it because `UserControllerTest` is `@Ignore`. Fix aligns with RealWorld spec: register needs email + username + password; login needs email + password.
 
-The current fix matches the RealWorld spec and the rest of the codebase: registration requires email + username + password; login requires email + password.
+---
 
-2026-06-30 16:45:08-04:00
+**2026-06-30 16:45**
 
-@src/test/kotlin/io/realworld/app/web/rules/AppRule.kt i like previous version where time units are spelled out. if it still works, i prefer no changing that.
+`AppRule.kt`: prefer the previous version with spelled-out time units if it still works.
 
-2026-06-30 16:48:08-04:00
+---
 
-take it back. lets use new syntax, working around 3 agruments no longer allowed, causes a bit too much trickery with subtle stop() calling. previous syntax looks clean.
+**2026-06-30 16:48**
 
-``` @AppRule.kt (11-13) 
+Revert that — keep the new two-argument `stop()` syntax. Avoid workarounds for the deprecated three-argument API; the previous call style is cleaner. See `AppRule.kt` lines 11–13.
 
-2026-06-30 16:56:08-04:00
+---
 
-@PLAN.md let's implement OPTION A. article favourite count endpoint . verify it does not exist before. lets add test coverage that is run part of ./gradlew test . read the rest of PLAN.md that would relate to implementation of option a.
+**2026-06-30 16:56**
 
-2026-06-30 17:11:08-04:00
-got back implementation in:
-* 9 file changes
-* 3 new files
+Implement PLAN.md Option A: article favorites count endpoint. Confirm it does not exist yet. Add tests that run under `./gradlew test`. Read the rest of PLAN.md for anything relevant to Option A.
 
-running tests
+---
 
-2026-06-30 17:33:08-04:00
+**2026-06-30 17:11**
 
-add comments explaining all new functions added. arguments.
+Implementation returned: 9 files changed, 3 new files. Running tests.
 
-* appconfig.kt
-add comments about why we are changing setup()
-* why we need a unique dbName, how it does not work for us before.
-* server() * why are we messing with that? it looks almost identical to what it was before
-* install(StatusPages)  . what's with new exception handling ? we did not have them before? no controller needed those active?
+---
 
-*dbConfig.kt:
-* why is this here? @DbConfig.kt (25-27)  transactions need to behave somehow different?
+**2026-06-30 17:33**
 
-* article Repository: comment new functions . 
+Add comments for all new functions and their arguments:
 
-document: @TagRepository.kt (27-30)
- document: class, and function: @ArticleService.kt (6-16) 
+- **AppConfig.kt** — why `setup()` changed; unique `dbName` and why shared DB failed before; why `server()` was extracted; new `StatusPages` handlers vs old behavior
+- **DbConfig.kt** — why schema creation lives in `setup()` (`DbConfig.kt` lines 25–27)
+- **ArticleRepository** — document new functions
+- **TagRepository.kt** (lines 27–30), **ArticleService.kt** (class + lines 6–16)
+- **String.kt** (lines 12–14) — purpose of `toSlug()`
+- **ArticleController.kt** — `popularFeed`, `create`, `favorite`, `parseQueryInt`
+- **PopularArticleFeedControllerTest.kt** — purpose of each test/helper
+- **HttpUtil.kt** (lines 20–22) — why `FAIL_ON_UNKNOWN_PROPERTIES` is needed
+- **AppRule.kt** (lines 13–20, 28–29) — dynamic ports and sleep delays
 
-what's the purpose of this function? @String.kt (12-14)
+---
 
- document: @ArticleController.kt (31-38) , @ArticleController.kt (45-53) and 2 others
+**2026-06-30 18:02**
 
-document, purpose of each new function
-@PopularArticleFeedControllerTest.kt (1-137) 
+For all staged files: add per-file change comments. Preview the git commit message. Local commit only — do not push.
 
-why is this required? @HttpUtil.kt (20-22) 
+---
 
-this looks horrible: @AppRule.kt (28-29) 
-why in the world are we introducing timing directives?
+**2026-06-30 18:04**
 
-what's with dynamic ports, how come what we had before was not sufficient?
-@AppRule.kt (13-20) 
+Implement PLAN.md Part 4: GitHub Actions CI/CD.
 
-2026-06-30 18:02:08-04:00
+---
 
-take all staged files. create comments for each file changed and why we are changing things inside each file.
-let me preview the  git commit message.
-and only local commit (dont push nothing to remote)
+**2026-06-30 18:12**
 
-2026-06-30 18:04:08-04:00
-let's implement Part4:@PLAN.md (87-88) 
+CI should trigger on `master` only (no `main`). Update README.md with a link to `testing.md` covering `gradle.yml` and local run notes for `.github/workflows/spec-api.yml`.
 
-2026-06-30 18:12:08-04:00
-don't need to add "main" branch for ci. did not have before.
-update README.md to include link to `testing.md` which should include docs for gradle.yaml overview, local run notes for @.github/workflows/spec-api.yml 
+---
 
-2026-06-30 18:20:08-04:00
-@run-api-tests.sh (5-6)  what's with this site? its not a real url. can we just remove the default cloud url, and just error out if nothing is passed in. show usage too, this way can instruct that cloud url pointing is possible. show example url. 
+**2026-06-30 18:20**
+
+`run-api-tests.sh` (lines 5–6): the default cloud URL is stale. Remove it; require `APIURL` and print usage on error. Usage should show local and optional hosted examples.

--- a/prompts-history.md
+++ b/prompts-history.md
@@ -1,0 +1,64 @@
+2026-06-30 15:36:08-04:00
+@README.md . gradlew clean install is failing. figure out what's wrong.
+
+Latest JDK25 is too new, using JDK21
+
+2026-06-30 15:43:08-04:00
+you see my terminal output when I try to run ./gradlew clean install ?
+
+extra:
+first run outside 
+
+2026-06-30 15:52:08-04:00
+nope. build fails for both `gradlew clean install` and `gradlew clean build`
+
+2026-06-30 16:01:08-04:00
+create local-development-environment.md with how to run the project cleanly, including nix-shell . how to install nix-shell and commands to run after.
+
+document JAVA_HOME environment variable details.
+
+2026-06-30 16:05:08-04:00
+update @local-development-environment.md  . dont need to mention JDK25 , that was just a starting point. we are just documenting how to run the project now. never mind previous shell.nix
+
+2026-06-30 16:13:08-04:00
+check out my terminal , ./gradlew run shows a stacktrace with errors. port 8080 does not start listenning . some server is not standing up. there should be no external services requirements.
+
+2026-06-30 16:20:08-04:00
+you test yourself. and access endpoint that works. hit existing restful endpoint to create one entity and retrieve it back. i want a working server.
+
+2026-06-30 16:29:08-04:00
+
+bellow now works
+
+# 1. Create user
+curl -X POST http://localhost:8080/users \
+  -H "Content-Type: application/json" \
+  -d '{"user":{"email":"you@example.com","password":"secret123","username":"you"}}'
+
+# 2. Retrieve user (use token from step 1)
+curl http://localhost:8080/user \
+  -H "Authorization: Token <token>"
+
+2026-06-30 16:41:08-04:00
+@src/main/kotlin/io/realworld/app/domain/User.kt ln: 11 . before UserDTO required empty password , and now we are not allowing blank password? before userdto was creating random password / username ? obvious bug . or logic oversight ?
+
+Answer:
+Most likely cause
+
+A missing ! — the intended checks were almost certainly:
+
+!user.password.isNullOrBlank() &&
+!user.username.isNullOrBlank()
+Same pattern was wrong in validLogin() and validToUpdate(). Tests didn’t catch it because UserControllerTest is marked @Ignore.
+
+The current fix matches the RealWorld spec and the rest of the codebase: registration requires email + username + password; login requires email + password.
+
+2026-06-30 16:45:08-04:00
+
+@src/test/kotlin/io/realworld/app/web/rules/AppRule.kt i like previous version where time units are spelled out. if it still works, i prefer no changing that.
+
+2026-06-30 16:48:08-04:00
+
+take it back. lets use new syntax, working around 3 agruments no longer allowed, causes a bit too much trickery with subtle stop() calling. previous syntax looks clean.
+
+``` @AppRule.kt (11-13) 

--- a/prompts-history.md
+++ b/prompts-history.md
@@ -62,3 +62,47 @@ The current fix matches the RealWorld spec and the rest of the codebase: registr
 take it back. lets use new syntax, working around 3 agruments no longer allowed, causes a bit too much trickery with subtle stop() calling. previous syntax looks clean.
 
 ``` @AppRule.kt (11-13) 
+
+2026-06-30 16:56:08-04:00
+
+@PLAN.md let's implement OPTION A. article favourite count endpoint . verify it does not exist before. lets add test coverage that is run part of ./gradlew test . read the rest of PLAN.md that would relate to implementation of option a.
+
+2026-06-30 17:11:08-04:00
+got back implementation in:
+* 9 file changes
+* 3 new files
+
+running tests
+
+2026-06-30 17:33:08-04:00
+
+add comments explaining all new functions added. arguments.
+
+* appconfig.kt
+add comments about why we are changing setup()
+* why we need a unique dbName, how it does not work for us before.
+* server() * why are we messing with that? it looks almost identical to what it was before
+* install(StatusPages)  . what's with new exception handling ? we did not have them before? no controller needed those active?
+
+*dbConfig.kt:
+* why is this here? @DbConfig.kt (25-27)  transactions need to behave somehow different?
+
+* article Repository: comment new functions . 
+
+document: @TagRepository.kt (27-30)
+ document: class, and function: @ArticleService.kt (6-16) 
+
+what's the purpose of this function? @String.kt (12-14)
+
+ document: @ArticleController.kt (31-38) , @ArticleController.kt (45-53) and 2 others
+
+document, purpose of each new function
+@PopularArticleFeedControllerTest.kt (1-137) 
+
+why is this required? @HttpUtil.kt (20-22) 
+
+this looks horrible: @AppRule.kt (28-29) 
+why in the world are we introducing timing directives?
+
+what's with dynamic ports, how come what we had before was not sufficient?
+@AppRule.kt (13-20) 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,17 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.vim
+    pkgs.zellij
+    pkgs.zulu25
+    pkgs.gradle
+  ];
+
+  shellHook = ''
+    echo "java 25, vim and zellij are now available";
+ '';
+
+  REGISTRY_USERNAME = "igor";
+}
+

--- a/shell.nix
+++ b/shell.nix
@@ -4,14 +4,15 @@ pkgs.mkShell {
   buildInputs = [
     pkgs.vim
     pkgs.zellij
-    pkgs.zulu25
-    pkgs.gradle
+    pkgs.zulu21
   ];
 
   shellHook = ''
-    echo "java 25, vim and zellij are now available";
- '';
+    export JAVA_HOME="${pkgs.zulu21}"
+    export PATH="$JAVA_HOME/bin:$PATH"
+    echo "java 21, vim and zellij are now available";
+    echo "JAVA_HOME=$JAVA_HOME"
+  '';
 
   REGISTRY_USERNAME = "igor";
 }
-

--- a/spec-api/README.md
+++ b/spec-api/README.md
@@ -2,10 +2,12 @@
 
 ## Running API tests locally
 
-To locally run the provided Postman collection against your backend, execute:
+`APIURL` is required. Run `./run-api-tests.sh --help` for usage and examples.
+
+Against this backend (no `/api` prefix, port 8080):
 
 ```
-APIURL=http://localhost:3000/api ./run-api-tests.sh
+APIURL=http://localhost:8080 ./run-api-tests.sh
 ```
 
 For more details, see [`run-api-tests.sh`](run-api-tests.sh).

--- a/spec-api/run-api-tests.sh
+++ b/spec-api/run-api-tests.sh
@@ -1,14 +1,47 @@
 #!/usr/bin/env bash
-set -x
+set -euo pipefail
+[[ "${DEBUG:-}" == "1" ]] && set -x
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-APIURL=${APIURL:-https://conduit.productionready.io/api}
-USERNAME=${USERNAME:-u`date +%s`}
+usage() {
+  cat <<'EOF'
+Usage: APIURL=<base-url> [USERNAME=...] [EMAIL=...] [PASSWORD=...] spec-api/run-api-tests.sh
+
+Run the RealWorld Postman collection against a Conduit-compatible API.
+
+Required:
+  APIURL   Base URL for API requests (no trailing slash)
+
+Examples:
+  # This project (no /api prefix):
+  APIURL=http://localhost:8080 spec-api/run-api-tests.sh
+
+  # Hosted RealWorld reference API (optional):
+  APIURL=https://api.realworld.io/api spec-api/run-api-tests.sh
+
+Optional:
+  USERNAME  Default: u<timestamp>
+  EMAIL     Default: <USERNAME>@mail.com
+  PASSWORD  Default: password
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ -z "${APIURL:-}" ]]; then
+  usage >&2
+  exit 1
+fi
+
+USERNAME=${USERNAME:-u$(date +%s)}
 EMAIL=${EMAIL:-$USERNAME@mail.com}
 PASSWORD=${PASSWORD:-password}
 
-npx newman run $SCRIPTDIR/Conduit.postman_collection.json \
+npx newman run "$SCRIPTDIR/Conduit.postman_collection.json" \
   --delay-request 500 \
   --global-var "APIURL=$APIURL" \
   --global-var "USERNAME=$USERNAME" \

--- a/src/main/kotlin/io/realworld/app/config/AppConfig.kt
+++ b/src/main/kotlin/io/realworld/app/config/AppConfig.kt
@@ -19,6 +19,8 @@ import io.ktor.server.engine.EngineAPI
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.util.KtorExperimentalAPI
+import io.realworld.app.domain.exceptions.NotFoundException
+import io.realworld.app.domain.exceptions.UnauthorizedException
 import io.realworld.app.utils.JwtProvider
 import io.realworld.app.web.ErrorResponse
 import io.realworld.app.web.articles
@@ -34,22 +36,39 @@ import org.kodein.di.generic.instance
 
 const val SERVER_PORT = 8080
 
+/**
+ * Boots the embedded Ktor server and connects to an in-memory H2 database.
+ *
+ * @param isCio when true uses the CIO engine (lighter, good for tests); otherwise Netty
+ * @param port HTTP port to bind; defaults to [SERVER_PORT] for `./gradlew run`, tests pass a free port
+ *
+ * Each call uses a unique H2 database name (`test_<nanoTime>`) so integration tests get a clean
+ * slate. Previously all tests shared one in-memory DB (`jdbc:h2:mem:DATABASE_TO_UPPER=false`), so
+ * data from one test leaked into the next (e.g. articlesCount was 6 instead of 2). A unique name
+ * gives each test run its own isolated database.
+ */
 @KtorExperimentalAPI
 @EngineAPI
-fun setup(isCio: Boolean = true): BaseApplicationEngine {
-    DbConfig.setup("jdbc:h2:mem:DATABASE_TO_UPPER=false;", "sa", "")
-    return server(if (isCio) CIO else Netty)
+fun setup(isCio: Boolean = true, port: Int = SERVER_PORT): BaseApplicationEngine {
+    val dbName = "test_${System.nanoTime()}"
+    DbConfig.setup("jdbc:h2:mem:$dbName;DATABASE_TO_UPPER=false;", "sa", "")
+    return server(if (isCio) CIO else Netty, port)
 }
 
+/**
+ * Creates the embedded server instance. Extracted from [setup] only so tests can pass a custom
+ * [port]; the body is otherwise unchanged from the original (engine, watchPaths, mainModule).
+ */
 @KtorExperimentalAPI
 @EngineAPI
 fun server(
     engine: ApplicationEngineFactory<BaseApplicationEngine,
-        out ApplicationEngine.Configuration>
+        out ApplicationEngine.Configuration>,
+    port: Int = SERVER_PORT
 ): BaseApplicationEngine {
     return embeddedServer(
         engine,
-        port = SERVER_PORT,
+        port = port,
         watchPaths = listOf("mainModule"),
         module = Application::mainModule
     )
@@ -79,9 +98,25 @@ fun Application.mainModule() {
             }
         }
     }
+    // StatusPages existed before but only mapped every Exception → 500. The article endpoints
+    // throw domain/validation exceptions that need proper HTTP status codes (401, 404, 422).
+    // Existing user controllers did not rely on these handlers — they returned DTOs directly.
+    // New article controllers throw instead, so these handlers are required for correct responses.
     install(StatusPages) {
-        exception(Exception::class.java) {
-            val errorResponse = ErrorResponse(mapOf("error" to listOf("detail", this.toString())))
+        exception<UnauthorizedException> { cause ->
+            val errorResponse = ErrorResponse(mapOf("error" to listOf("detail", cause.message)))
+            context.respond(HttpStatusCode.Unauthorized, errorResponse)
+        }
+        exception<NotFoundException> { cause ->
+            val errorResponse = ErrorResponse(mapOf("error" to listOf("detail", cause.message)))
+            context.respond(HttpStatusCode.NotFound, errorResponse)
+        }
+        exception<IllegalArgumentException> { cause ->
+            val errorResponse = ErrorResponse(mapOf("error" to listOf("detail", cause.message)))
+            context.respond(HttpStatusCode.UnprocessableEntity, errorResponse)
+        }
+        exception<Exception> { cause ->
+            val errorResponse = ErrorResponse(mapOf("error" to listOf("detail", cause.toString())))
             context.respond(
                 HttpStatusCode.InternalServerError, errorResponse
             )

--- a/src/main/kotlin/io/realworld/app/config/DbConfig.kt
+++ b/src/main/kotlin/io/realworld/app/config/DbConfig.kt
@@ -2,8 +2,16 @@ package io.realworld.app.config
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import io.realworld.app.domain.repository.ArticleTags
+import io.realworld.app.domain.repository.Articles
+import io.realworld.app.domain.repository.Favorites
+import io.realworld.app.domain.repository.Follows
+import io.realworld.app.domain.repository.Tags
+import io.realworld.app.domain.repository.Users
 import org.h2.tools.Server
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.transactions.transaction
 
 object DbConfig {
     fun setup(jdbcUrl: String, username: String, password: String) {
@@ -14,5 +22,12 @@ object DbConfig {
             config.password = password
         }
         Database.connect(HikariDataSource(config))
+        // Schema creation lives here (not only in repository init blocks) because Kodein
+        // repositories are singletons: their init { SchemaUtils.create(...) } runs once per JVM.
+        // Each test calls setup() with a new H2 URL, so tables must be created on every connect.
+        // Exposed requires DDL inside a transaction block — same as repository init blocks.
+        transaction {
+            SchemaUtils.create(Users, Follows, Tags, Articles, ArticleTags, Favorites)
+        }
     }
 }

--- a/src/main/kotlin/io/realworld/app/config/ModulesConfig.kt
+++ b/src/main/kotlin/io/realworld/app/config/ModulesConfig.kt
@@ -1,7 +1,9 @@
 package io.realworld.app.config
 
+import io.realworld.app.domain.repository.ArticleRepository
 import io.realworld.app.domain.repository.TagRepository
 import io.realworld.app.domain.repository.UserRepository
+import io.realworld.app.domain.service.ArticleService
 import io.realworld.app.domain.service.TagService
 import io.realworld.app.domain.service.UserService
 import io.realworld.app.utils.JwtProvider
@@ -22,7 +24,9 @@ object ModulesConfig {
         bind() from singleton { UserRepository() }
     }
     private val articleModule = Kodein.Module("ARTICLE") {
-        bind() from singleton { ArticleController() }
+        bind() from singleton { ArticleController(instance()) }
+        bind() from singleton { ArticleService(instance()) }
+        bind() from singleton { ArticleRepository(instance(), instance()) }
     }
     private val profileModule = Kodein.Module("PROFILE") {
         bind() from singleton { ProfileController() }

--- a/src/main/kotlin/io/realworld/app/domain/User.kt
+++ b/src/main/kotlin/io/realworld/app/domain/User.kt
@@ -8,8 +8,8 @@ data class UserDTO(val user: User? = null) {
         require(
             user != null &&
                 user.email.isEmailValid() &&
-                user.password.isNullOrBlank() &&
-                user.username.isNullOrBlank()
+                !user.password.isNullOrBlank() &&
+                !user.username.isNullOrBlank()
         ) { "User is invalid." }
         return user
     }
@@ -18,7 +18,7 @@ data class UserDTO(val user: User? = null) {
         require(
             user != null &&
                 user.email.isEmailValid() &&
-                user.password.isNullOrBlank()
+                !user.password.isNullOrBlank()
         ) { "Email or password is invalid." }
         return user
     }
@@ -26,11 +26,7 @@ data class UserDTO(val user: User? = null) {
     fun validToUpdate(): User {
         require(
             user != null &&
-                user.email.isEmailValid() &&
-                user.password.isNullOrBlank() &&
-                user.username.isNullOrBlank() &&
-                user.bio.isNullOrBlank() &&
-                user.image.isNullOrBlank()
+                user.email.isEmailValid()
         ) { "User is invalid." }
         return user
     }

--- a/src/main/kotlin/io/realworld/app/domain/repository/ArticleRepository.kt
+++ b/src/main/kotlin/io/realworld/app/domain/repository/ArticleRepository.kt
@@ -1,0 +1,174 @@
+package io.realworld.app.domain.repository
+
+import io.realworld.app.domain.Article
+import io.realworld.app.domain.exceptions.NotFoundException
+import io.realworld.app.ext.toSlug
+import org.jetbrains.exposed.dao.LongIdTable
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.JoinType
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+
+internal object Articles : LongIdTable() {
+    val slug: Column<String> = varchar("slug", 255).uniqueIndex()
+    val title: Column<String> = varchar("title", 500)
+    val description: Column<String?> = varchar("description", 1000).nullable()
+    val body: Column<String> = text("body")
+    val author: Column<Long> = long("author_id")
+    val createdAt: Column<Long> = long("created_at")
+    val updatedAt: Column<Long> = long("updated_at")
+}
+
+internal object ArticleTags : Table() {
+    val article: Column<Long> = long("article_id").primaryKey()
+    val tag: Column<Long> = long("tag_id").primaryKey()
+}
+
+internal object Favorites : Table() {
+    val user: Column<Long> = long("user_id").primaryKey()
+    val article: Column<Long> = long("article_id").primaryKey()
+}
+
+class ArticleRepository(
+    private val userRepository: UserRepository,
+    private val tagRepository: TagRepository
+) {
+    init {
+        // Kept for `./gradlew run` on first startup; [DbConfig.setup] also creates these tables
+        // so per-test databases work when this singleton init does not re-run.
+        transaction {
+            SchemaUtils.create(Articles, ArticleTags, Favorites)
+        }
+    }
+
+    /**
+     * Persists a new article for [authorEmail] and links [article.tagList] to tag rows.
+     * Slug is derived from the title via [toSlug]. Returns the saved article with author populated.
+     */
+    fun create(authorEmail: String, article: Article): Article {
+        val author = userRepository.findByEmail(authorEmail)
+            ?: throw NotFoundException("Author not found.")
+        val slug = (article.title ?: "").toSlug()
+        val now = System.currentTimeMillis()
+
+        return transaction {
+            val articleId = Articles.insertAndGetId { row ->
+                row[Articles.slug] = slug
+                row[Articles.title] = article.title!!
+                row[Articles.description] = article.description
+                row[Articles.body] = article.body
+                row[Articles.author] = author.id!!
+                row[Articles.createdAt] = now
+                row[Articles.updatedAt] = now
+            }.value
+
+            article.tagList.forEach { tagName ->
+                val tagId = findOrCreateTagId(tagName)
+                ArticleTags.insert {
+                    it[ArticleTags.article] = articleId
+                    it[ArticleTags.tag] = tagId
+                }
+            }
+
+            val row = Articles.select { Articles.id eq articleId }.first()
+            toDomain(row, author.id)
+        }
+    }
+
+    /**
+     * Records [userEmail] favoriting the article identified by [slug] (idempotent if already favorited).
+     * Returns the article with updated favoritesCount and favorited flag for the viewer.
+     */
+    fun favorite(userEmail: String, slug: String): Article {
+        val user = userRepository.findByEmail(userEmail)
+            ?: throw NotFoundException("User not found.")
+
+        return transaction {
+            val row = Articles.select { Articles.slug eq slug }.firstOrNull()
+                ?: throw NotFoundException("Article not found.")
+            val articleId = row[Articles.id].value
+
+            val exists = Favorites.select {
+                (Favorites.user eq user.id!!) and (Favorites.article eq articleId)
+            }.count() > 0
+            if (!exists) {
+                Favorites.insert {
+                    it[Favorites.user] = user.id!!
+                    it[Favorites.article] = articleId
+                }
+            }
+
+            toDomain(row, user.id)
+        }
+    }
+
+    /**
+     * Returns all articles sorted by favorites count (desc), then slug, with pagination.
+     *
+     * @param viewerEmail authenticated user email; used to set each article's favorited flag
+     * @param limit max rows in the page (validated upstream in [ArticleService])
+     * @param offset rows to skip before [limit]
+     * @return pair of (page of articles, total count before pagination)
+     */
+    fun findPopular(viewerEmail: String?, limit: Int, offset: Int): Pair<List<Article>, Int> {
+        val viewer = viewerEmail?.let { userRepository.findByEmail(it) }
+
+        return transaction {
+            val favoriteCounts = Favorites.selectAll()
+                .groupBy { it[Favorites.article] }
+                .mapValues { (_, rows) -> rows.size.toLong() }
+
+            val sorted = Articles.selectAll()
+                .map { row ->
+                    val articleId = row[Articles.id].value
+                    toDomain(row, viewer?.id, favoriteCounts[articleId] ?: 0)
+                }
+                .sortedWith(compareByDescending<Article> { it.favoritesCount }.thenBy { it.slug })
+
+            val total = sorted.size
+            val page = sorted.drop(offset).take(limit)
+            page to total
+        }
+    }
+
+    /** Looks up a tag by [name] in the current transaction, inserting it if missing. */
+    private fun findOrCreateTagId(name: String): Long =
+        Tags.select { Tags.name eq name }.firstOrNull()?.get(Tags.id)?.value
+            ?: Tags.insertAndGetId { row -> row[Tags.name] = name }.value
+
+    /** Maps a DB row to [Article], optionally reusing a precomputed [favoritesCount] for sorting. */
+    private fun toDomain(row: ResultRow, viewerId: Long?, favoritesCount: Long? = null): Article {
+        val articleId = row[Articles.id].value
+        val author = Users.select { Users.id eq row[Articles.author] }
+            .first().let { Users.toDomain(it) }
+        val tags = ArticleTags.join(Tags, JoinType.INNER, ArticleTags.tag, Tags.id)
+            .select { ArticleTags.article eq articleId }
+            .map { it[Tags.name] }
+        val count = favoritesCount ?: Favorites.select { Favorites.article eq articleId }.count()
+        val favorited = viewerId?.let { viewer ->
+            Favorites.select {
+                (Favorites.user eq viewer) and (Favorites.article eq articleId)
+            }.count() > 0
+        } ?: false
+
+        return Article(
+            slug = row[Articles.slug],
+            title = row[Articles.title],
+            description = row[Articles.description],
+            body = row[Articles.body],
+            tagList = tags,
+            createdAt = java.util.Date(row[Articles.createdAt]),
+            updatedAt = java.util.Date(row[Articles.updatedAt]),
+            favorited = favorited,
+            favoritesCount = count.toLong(),
+            author = author.copy(password = null, token = null)
+        )
+    }
+}

--- a/src/main/kotlin/io/realworld/app/domain/repository/TagRepository.kt
+++ b/src/main/kotlin/io/realworld/app/domain/repository/TagRepository.kt
@@ -3,6 +3,9 @@ package io.realworld.app.domain.repository
 import org.jetbrains.exposed.dao.LongIdTable
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 
@@ -19,5 +22,14 @@ class TagRepository {
 
     fun findAll(): List<String> = transaction {
         Tags.selectAll().map { it[Tags.name] }
+    }
+
+    /**
+     * Returns the id of the tag named [name], creating the row if it does not exist yet.
+     * Used when attaching tags to articles during create; avoids duplicate tag names.
+     */
+    fun findOrCreate(name: String): Long = transaction {
+        Tags.select { Tags.name eq name }.firstOrNull()?.get(Tags.id)?.value
+            ?: Tags.insertAndGetId { row -> row[Tags.name] = name }.value
     }
 }

--- a/src/main/kotlin/io/realworld/app/domain/service/ArticleService.kt
+++ b/src/main/kotlin/io/realworld/app/domain/service/ArticleService.kt
@@ -1,0 +1,27 @@
+package io.realworld.app.domain.service
+
+import io.realworld.app.domain.Article
+import io.realworld.app.domain.repository.ArticleRepository
+
+/** Service layer for article write/read operations used by [ArticleController]. */
+class ArticleService(private val articleRepository: ArticleRepository) {
+
+    /** Creates an article authored by the user identified by [email]. */
+    fun create(email: String, article: Article): Article = articleRepository.create(email, article)
+
+    /** Adds a favorite for [email] on the article with [slug]. */
+    fun favorite(email: String, slug: String): Article = articleRepository.favorite(email, slug)
+
+    /**
+     * Popular feed: articles ordered by favorites count with pagination.
+     *
+     * @param email viewer email (from JWT); passed through for favorited flags on each article
+     * @param limit page size; must be > 0
+     * @param offset number of articles to skip; must be >= 0
+     */
+    fun findPopular(email: String?, limit: Int, offset: Int): Pair<List<Article>, Int> {
+        require(limit > 0) { "limit must be a positive integer." }
+        require(offset >= 0) { "offset must be a non-negative integer." }
+        return articleRepository.findPopular(email, limit, offset)
+    }
+}

--- a/src/main/kotlin/io/realworld/app/ext/String.kt
+++ b/src/main/kotlin/io/realworld/app/ext/String.kt
@@ -8,3 +8,11 @@ const val MAIL_REGEX = ("^(([\\w-]+\\.)+[\\w-]+|([a-zA-Z]|[\\w-]{2,}))@"
     + "([a-zA-Z]+[\\w-]+\\.)+[a-zA-Z]{2,4})$")
 
 fun String.isEmailValid(): Boolean = !this.isNullOrBlank() && Regex(MAIL_REGEX).matches(this)
+
+/**
+ * Converts a title to a URL slug (RealWorld convention): lowercase, non-alphanumeric → hyphens.
+ * Example: "Many favorites" → "many-favorites". Used when persisting articles and in tests.
+ */
+fun String.toSlug(): String = lowercase()
+    .replace(Regex("[^a-z0-9]+"), "-")
+    .trim('-')

--- a/src/main/kotlin/io/realworld/app/web/Router.kt
+++ b/src/main/kotlin/io/realworld/app/web/Router.kt
@@ -43,7 +43,10 @@ fun Routing.profiles(profileController: ProfileController) {
 fun Routing.articles(articleController: ArticleController, commentController: CommentController) {
     route("articles") {
         authenticate {
-            get("feed") { articleController.feed(this.context) }
+            route("feed") {
+                get { articleController.feed(this.context) }
+                get("popular") { articleController.popularFeed(this.context) }
+            }
             route("{slug}") {
                 route("comments") {
                     post { commentController.add(this.context) }

--- a/src/main/kotlin/io/realworld/app/web/controllers/ArticleController.kt
+++ b/src/main/kotlin/io/realworld/app/web/controllers/ArticleController.kt
@@ -1,12 +1,17 @@
 package io.realworld.app.web.controllers
 
 import io.ktor.application.ApplicationCall
+import io.ktor.auth.authentication
 import io.ktor.request.receive
+import io.ktor.response.respond
+import io.realworld.app.domain.Article
 import io.realworld.app.domain.ArticleDTO
 import io.realworld.app.domain.ArticlesDTO
+import io.realworld.app.domain.User
+import io.realworld.app.domain.exceptions.UnauthorizedException
+import io.realworld.app.domain.service.ArticleService
 
-class ArticleController {
-//class ArticleController(private val articleService: ArticleService) {
+class ArticleController(private val articleService: ArticleService) {
 
     fun findBy(ctx: ApplicationCall): ArticlesDTO {
         val tag = ctx.parameters["tag"]
@@ -14,64 +19,86 @@ class ArticleController {
         val favorited = ctx.parameters["favorited"]
         val limit = ctx.parameters["limit"] ?: "20"
         val offset = ctx.parameters["offset"] ?: "0"
-//        articleService.findBy(tag, author, favorited, limit.toInt(), offset.toInt()).also { articles ->
-//            ctx.json(ArticlesDTO(articles, articles.size))
-//        }
         return ArticlesDTO(listOf(), 1)
     }
 
     fun feed(ctx: ApplicationCall): ArticlesDTO {
         val limit = ctx.parameters["limit"] ?: "20"
         val offset = ctx.parameters["offset"] ?: "0"
-//        articleService.findFeed(ctx.attribute("email"), limit.toInt(), offset.toInt()).also { articles ->
-//            ctx.json(ArticlesDTO(articles, articles.size))
-//        }
         return ArticlesDTO(listOf(), 1)
+    }
+
+    /**
+     * GET /articles/feed/popular — articles sorted by favorites count (desc), paginated.
+     * Requires JWT; query params [limit] (default 20, must be > 0) and [offset] (default 0, >= 0).
+     */
+    suspend fun popularFeed(ctx: ApplicationCall) {
+        val limit = parseQueryInt(ctx.parameters["limit"], 20, "limit") { it > 0 }
+        val offset = parseQueryInt(ctx.parameters["offset"], 0, "offset") { it >= 0 }
+        val email = ctx.authentication.principal<User>()?.email
+            ?: throw UnauthorizedException("Authentication required.")
+        val (articles, count) = articleService.findPopular(email, limit, offset)
+        ctx.respond(ArticlesDTO(articles, count))
     }
 
     fun get(ctx: ApplicationCall): ArticleDTO {
         ctx.parameters["slug"]
-        //                articleService.findBySlug(slug).apply {
-//                    ctx.json(ArticleDTO(this))
-//                }
         return ArticleDTO(null)
     }
 
-    suspend fun create(ctx: ApplicationCall): ArticleDTO {
-        ctx.receive<ArticleDTO>()
-        //            articleService.create(ctx.attribute("email"), article).apply {
-//                ctx.json(ArticleDTO(this))
-//            }
-        return ArticleDTO(null)
+    /** POST /articles — creates an article for the authenticated user. Body: ArticleDTO. */
+    suspend fun create(ctx: ApplicationCall) {
+        val email = ctx.authentication.principal<User>()?.email
+            ?: throw UnauthorizedException("Authentication required.")
+        val article = ctx.receive<ArticleDTO>().article
+            ?: throw IllegalArgumentException("Article is invalid.")
+        require(!article.title.isNullOrBlank()) { "Article title is required." }
+        require(!article.body.isBlank()) { "Article body is required." }
+        ctx.respond(ArticleDTO(articleService.create(email, article)))
     }
 
     suspend fun update(ctx: ApplicationCall): ArticleDTO {
         val slug = ctx.parameters["slug"]
         ctx.receive<ArticleDTO>()
-        //            articleService.update(slug, article).apply {
-//                ctx.json(ArticleDTO(this))
-//            }
         return ArticleDTO(null)
     }
 
     fun delete(ctx: ApplicationCall) {
         ctx.parameters["slug"]
-        //            articleService.delete(slug)
     }
 
-    fun favorite(ctx: ApplicationCall): ArticleDTO {
-        ctx.parameters["slug"]
-        //            articleService.favorite(ctx.attribute("email"), slug).apply {
-//                ctx.json(ArticleDTO(this))
-//            }
-        return ArticleDTO(null)
+    /** POST /articles/:slug/favorite — idempotently favorites an article for the authenticated user. */
+    suspend fun favorite(ctx: ApplicationCall) {
+        val email = ctx.authentication.principal<User>()?.email
+            ?: throw UnauthorizedException("Authentication required.")
+        val slug = ctx.parameters["slug"]
+            ?: throw IllegalArgumentException("Slug is required.")
+        ctx.respond(ArticleDTO(articleService.favorite(email, slug)))
     }
 
     fun unfavorite(ctx: ApplicationCall): ArticleDTO {
         ctx.parameters["slug"]
-        //            articleService.unfavorite(ctx.attribute("email"), slug).apply {
-//                ctx.json(ArticleDTO(this))
-//            }
         return ArticleDTO(null)
+    }
+
+    /**
+     * Parses an integer query parameter with a [default], or throws 422 via [IllegalArgumentException].
+     *
+     * @param raw query string value (null/blank → [default])
+     * @param default used when the param is omitted
+     * @param name param name for error messages (e.g. "limit", "offset")
+     * @param validate extra rule (e.g. { it > 0 } for limit)
+     */
+    private fun parseQueryInt(
+        raw: String?,
+        default: Int,
+        name: String,
+        validate: (Int) -> Boolean
+    ): Int {
+        if (raw.isNullOrBlank()) return default
+        val value = raw.toIntOrNull()
+            ?: throw IllegalArgumentException("$name must be a valid integer.")
+        require(validate(value)) { "$name is invalid." }
+        return value
     }
 }

--- a/src/test/kotlin/io/realworld/app/web/controllers/PopularArticleFeedControllerTest.kt
+++ b/src/test/kotlin/io/realworld/app/web/controllers/PopularArticleFeedControllerTest.kt
@@ -1,0 +1,148 @@
+package io.realworld.app.web.controllers
+
+import io.realworld.app.domain.Article
+import io.realworld.app.domain.ArticleDTO
+import io.realworld.app.domain.ArticlesDTO
+import io.realworld.app.ext.toSlug
+import io.realworld.app.web.rules.AppRule
+import io.realworld.app.web.util.HttpUtil
+import org.apache.http.HttpStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Integration tests for GET /articles/feed/popular (Option A: popular articles by favorites count).
+ * Uses [AppRule] to start a fresh server + DB per test. Runs with `./gradlew test` (not @Ignore).
+ */
+class PopularArticleFeedControllerTest {
+    @Rule
+    @JvmField
+    val appRule = AppRule()
+
+    /** Happy path: three articles with different favorite counts, assert sort order and counts. */
+    @Test
+    fun `returns articles sorted by favorites count descending`() {
+        val http = authenticatedHttp("popular-sorted@example.com", "popular_sorted")
+
+        val lowSlug = createArticle(http, "Few favorites", "few-favorites")
+        val highSlug = createArticle(http, "Many favorites", "many-favorites")
+        val midSlug = createArticle(http, "Some favorites", "some-favorites")
+
+        favoriteAs(_http = http, email = "fan1@example.com", username = "fan1", slug = highSlug)
+        favoriteAs(_http = http, email = "fan2@example.com", username = "fan2", slug = highSlug)
+        favoriteAs(_http = http, email = "fan3@example.com", username = "fan3", slug = highSlug)
+        favoriteAs(_http = http, email = "fan4@example.com", username = "fan4", slug = midSlug)
+        favoriteAs(_http = http, email = "fan5@example.com", username = "fan5", slug = midSlug)
+        favoriteAs(_http = http, email = "fan6@example.com", username = "fan6", slug = lowSlug)
+
+        val response = http.get<ArticlesDTO>("/articles/feed/popular")
+
+        assertEquals(HttpStatus.SC_OK, response.status)
+        assertEquals(3, response.body.articlesCount)
+        assertEquals(3, response.body.articles.size)
+        assertEquals("many-favorites", response.body.articles[0].slug)
+        assertEquals(3, response.body.articles[0].favoritesCount)
+        assertEquals("some-favorites", response.body.articles[1].slug)
+        assertEquals(2, response.body.articles[1].favoritesCount)
+        assertEquals("few-favorites", response.body.articles[2].slug)
+        assertEquals(1, response.body.articles[2].favoritesCount)
+    }
+
+    /** Pagination: limit=1 offset=1 returns the second-ranked article only; articlesCount is total. */
+    @Test
+    fun `supports limit and offset pagination`() {
+        val http = authenticatedHttp("popular-page@example.com", "popular_page")
+
+        val firstSlug = createArticle(http, "First article", "first-article")
+        val secondSlug = createArticle(http, "Second article", "second-article")
+
+        favoriteAs(_http = http, email = "pager1@example.com", username = "pager1", slug = firstSlug)
+        favoriteAs(_http = http, email = "pager2@example.com", username = "pager2", slug = firstSlug)
+        favoriteAs(_http = http, email = "pager3@example.com", username = "pager3", slug = secondSlug)
+
+        val response = http.get<ArticlesDTO>(
+            "/articles/feed/popular",
+            mapOf("limit" to 1, "offset" to 1)
+        )
+
+        assertEquals(HttpStatus.SC_OK, response.status)
+        assertEquals(2, response.body.articlesCount)
+        assertEquals(1, response.body.articles.size)
+        assertEquals("second-article", response.body.articles[0].slug)
+    }
+
+    /** Error case: no Authorization header → 401 (endpoint requires authentication). */
+    @Test
+    fun `rejects unauthenticated requests`() {
+        val http = HttpUtil(appRule.port)
+        val response = http.getRaw("/articles/feed/popular")
+
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, response.status)
+    }
+
+    /** Error case: negative limit → 422 with message mentioning limit. */
+    @Test
+    fun `rejects invalid limit`() {
+        val http = authenticatedHttp("popular-invalid@example.com", "popular_invalid")
+        createArticle(http, "Validation article", "validation-article")
+
+        val response = http.getRaw("/articles/feed/popular", mapOf("limit" to -1))
+
+        assertEquals(HttpStatus.SC_UNPROCESSABLE_ENTITY, response.status)
+        assertTrue(response.body.contains("limit"))
+    }
+
+    /** Error case: non-numeric offset → 422 with message mentioning offset. */
+    @Test
+    fun `rejects non-numeric offset`() {
+        val http = authenticatedHttp("popular-offset@example.com", "popular_offset")
+        createArticle(http, "Offset article", "offset-article")
+
+        val response = http.getRaw(
+            "/articles/feed/popular",
+            mapOf("offset" to "abc")
+        )
+
+        assertEquals(HttpStatus.SC_UNPROCESSABLE_ENTITY, response.status)
+        assertTrue(response.body.contains("offset"))
+    }
+
+    /** Registers and logs in a user; returns HttpUtil with Authorization header set. */
+    private fun authenticatedHttp(email: String, username: String): HttpUtil {
+        val http = HttpUtil(appRule.port)
+        http.registerUser(email, "password", username)
+        http.loginAndSetTokenHeader(email, "password")
+        return http
+    }
+
+    /** POST /articles with [title] and one [tag]; returns the generated slug for follow-up calls. */
+    private fun createArticle(http: HttpUtil, title: String, tag: String): String {
+        val expectedSlug = title.toSlug()
+        val response = http.post<ArticleDTO>(
+            "/articles",
+            ArticleDTO(
+                Article(
+                    title = title,
+                    description = "Description for $title",
+                    body = "Body for $title",
+                    tagList = listOf(tag)
+                )
+            )
+        )
+        assertEquals(HttpStatus.SC_OK, response.status)
+        assertNotNull(response.body.article)
+        assertEquals(expectedSlug, response.body.article?.slug)
+        return expectedSlug
+    }
+
+    /** Registers a separate user and favorites [slug] — simulates multiple users favoriting one article. */
+    private fun favoriteAs(_http: HttpUtil, email: String, username: String, slug: String) {
+        val fan = HttpUtil(appRule.port)
+        fan.registerUser(email, "password", username)
+        fan.loginAndSetTokenHeader(email, "password")
+        fan.post<ArticleDTO>("/articles/$slug/favorite")
+    }
+}

--- a/src/test/kotlin/io/realworld/app/web/rules/AppRule.kt
+++ b/src/test/kotlin/io/realworld/app/web/rules/AppRule.kt
@@ -19,6 +19,6 @@ class AppRule : ExternalResource() {
     }
 
     override fun after() {
-        app.stop(500, 500, TimeUnit.MILLISECONDS)
+        app.stop(500, 500)
     }
 }

--- a/src/test/kotlin/io/realworld/app/web/rules/AppRule.kt
+++ b/src/test/kotlin/io/realworld/app/web/rules/AppRule.kt
@@ -1,24 +1,41 @@
 package io.realworld.app.web.rules
 
+import io.ktor.server.engine.BaseApplicationEngine
 import io.ktor.server.engine.ConnectorType
 import io.realworld.app.config.SERVER_PORT
 import io.realworld.app.config.setup
 import io.realworld.app.web.util.HttpUtil
 import org.junit.rules.ExternalResource
+import java.net.ServerSocket
 import java.util.concurrent.TimeUnit
 
+/**
+ * JUnit rule: starts a Ktor app before each test and stops it after.
+ *
+ * Dynamic port: the original rule reused port 8080 and a single app instance. When tests run
+ * back-to-back, the previous server could still hold the port (BindException) or share DB state.
+ * We pick a free port via [ServerSocket(0)] and start a new app per test so each test is isolated.
+ *
+ * Sleeps: Ktor 1.x [BaseApplicationEngine.start]/[stop] are not fully synchronous from the caller's
+ * perspective. The brief pauses avoid flaky failures (requests before listen, or port not released).
+ * Not ideal, but the pragmatic fix without a richer test lifecycle API.
+ */
 class AppRule : ExternalResource() {
-    private val app = setup()
+    private lateinit var app: BaseApplicationEngine
     lateinit var http: HttpUtil
-    val port = app.environment.connectors.find { it.type == ConnectorType.HTTP }?.port ?: SERVER_PORT
+    val port: Int
+        get() = app.environment.connectors.find { it.type == ConnectorType.HTTP }?.port ?: SERVER_PORT
 
     override fun before() {
+        val freePort = ServerSocket(0).use { it.localPort }
+        app = setup(port = freePort)
         app.start()
-        TimeUnit.MILLISECONDS.sleep(500)
+        TimeUnit.MILLISECONDS.sleep(500) // wait for connector to accept connections
         http = HttpUtil(port)
     }
 
     override fun after() {
         app.stop(500, 500)
+        TimeUnit.MILLISECONDS.sleep(200) // allow socket + pool teardown before next test's port bind
     }
 }

--- a/src/test/kotlin/io/realworld/app/web/util/HttpUtil.kt
+++ b/src/test/kotlin/io/realworld/app/web/util/HttpUtil.kt
@@ -1,5 +1,6 @@
 package io.realworld.app.web.util
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.mashape.unirest.http.HttpResponse
 import com.mashape.unirest.http.ObjectMapper
@@ -16,7 +17,11 @@ class HttpUtil(port: Int) {
     init {
         Unirest.setObjectMapper(object : ObjectMapper {
             override fun <T> readValue(value: String, valueType: Class<T>): T {
-                return jacksonObjectMapper().readValue(value, valueType)
+                // Article JSON includes extra fields (e.g. author.profile) not on our DTOs.
+                // Without this, Jackson fails deserialization in tests even when we only assert status/body.
+                return jacksonObjectMapper()
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                    .readValue(value, valueType)
             }
 
             override fun writeValue(value: Any): String {
@@ -36,6 +41,10 @@ class HttpUtil(port: Int) {
 
     inline fun <reified T> get(path: String, params: Map<String, Any>? = null) =
         Unirest.get(origin + path).headers(headers).queryString(params).asObject(T::class.java)
+
+    /** GET without JSON parsing — used to assert 401/422 status and raw error body text. */
+    fun getRaw(path: String, params: Map<String, Any>? = null) =
+        Unirest.get(origin + path).headers(headers).queryString(params).asString()
 
     inline fun <reified T> put(path: String, body: Any) =
         Unirest.put(origin + path).headers(headers).body(body).asObject(T::class.java)

--- a/testing.md
+++ b/testing.md
@@ -1,0 +1,82 @@
+# Testing
+
+How CI runs tests and how to reproduce the same checks locally.
+
+For JDK setup and running the server, see [local-development-environment.md](local-development-environment.md).
+
+---
+
+## Gradle CI (`.github/workflows/gradle.yml`)
+
+Runs on every **push** and **pull request** to `master`.
+
+### What it does
+
+| Step | Action |
+|------|--------|
+| Matrix | JDK **17** and **21** (Eclipse Temurin), `fail-fast: false` |
+| Cache | `gradle/gradle-build-action@v3` caches Gradle dependencies between runs |
+| Build | `./gradlew build --no-daemon` |
+| Test | `./gradlew test --no-daemon` |
+| Report | `dorny/test-reporter` publishes JUnit XML from `build/test-results/test/*.xml` as GitHub check annotations |
+
+### Run locally
+
+Same commands CI uses (without the matrix — pick your installed JDK):
+
+```bash
+./gradlew build test
+```
+
+JUnit XML reports are written to `build/test-results/test/`.
+
+---
+
+## RealWorld API spec tests (`.github/workflows/spec-api.yml`)
+
+Bonus workflow: runs the [RealWorld Postman collection](spec-api/Conduit.postman_collection.json) against a live server via [newman](https://github.com/postmanlabs/newman).
+
+**Triggers:** push/PR to `master`, or manual run via **Actions → RealWorld API Spec Tests → Run workflow** (`workflow_dispatch`).
+
+**CI behavior:** the job uses `continue-on-error: true` because many RealWorld endpoints are still stubs in this codebase — failures are informational and do not block the main Gradle CI job.
+
+### What CI does
+
+1. Build the application (`./gradlew build`)
+2. Start the server in the background (`./gradlew run` on port **8080**)
+3. Wait until `GET /tags` responds
+4. Run `spec-api/run-api-tests.sh` with `APIURL=http://localhost:8080`
+
+### Important: no `/api` prefix
+
+This app serves routes at the root (e.g. `/users`, `/articles`), not under `/api`. Use:
+
+```bash
+APIURL=http://localhost:8080
+```
+
+The upstream [spec-api README](spec-api/README.md) uses `http://localhost:3000/api` — that does not apply to this fork.
+
+### Run locally
+
+**Prerequisites:** JDK 21 (or compatible), Node.js (for `npx newman`).
+
+```bash
+./gradlew build
+./gradlew run &
+```
+
+Wait until the server is up:
+
+```bash
+curl -sf http://localhost:8080/tags
+```
+
+Run the spec tests:
+
+```bash
+chmod +x spec-api/run-api-tests.sh
+APIURL=http://localhost:8080 spec-api/run-api-tests.sh
+```
+
+Stop the server when finished (`fg` then Ctrl+C, or kill the Gradle run process).


### PR DESCRIPTION
## Summary

Implements **PLAN.md Option A**: an authenticated endpoint that returns articles sorted by favorites count (descending), with `limit` and `offset` pagination. Also includes integration tests, CI/CD updates (Part 4), and local dev/testing documentation.

- **Endpoint:** `GET /articles/feed/popular` (this app uses no `/api` prefix, consistent with existing routes)
- **Supporting endpoints for tests:** `POST /articles`, `POST /articles/:slug/favorite`

## Approach

Followed existing **controller → service → repository** layering:

- `ArticleRepository` — `Articles`, `ArticleTags`, `Favorites` tables; `create`, `favorite`, `findPopular`
- `ArticleService` — validates `limit > 0` and `offset >= 0`
- `ArticleController.popularFeed` — JWT auth, query param parsing, returns `ArticlesDTO`

### Key decisions / trade-offs

| Decision | Rationale |
|----------|-----------|
| Route at `/articles/feed/popular` | Matches existing router style (no `/api` prefix) |
| Unique H2 DB per test `setup()` | Prevents data leaking between integration tests when sharing one in-memory DB |
| Schema creation in `DbConfig.setup()` | Kodein repositories are singletons; `init` blocks only run once per JVM |
| `StatusPages` for 401/404/422 | New article endpoints throw domain/validation exceptions; old user controllers returned DTOs directly |
| Per-test dynamic port in `AppRule` | Avoids `BindException` and flaky parallel test runs on fixed port 8080 |
| Spec-api CI job `continue-on-error: true` | Many RealWorld endpoints are still stubs; job is informational |

## Testing

Added `PopularArticleFeedControllerTest` (runs with `./gradlew test`, not `@Ignore`):

- Happy path — articles sorted by `favoritesCount` descending
- Pagination — `limit` and `offset`
- Error cases — unauthenticated (401), invalid `limit` (422), non-numeric `offset` (422)

Uses existing `AppRule` + `HttpUtil` integration test pattern.

### Agent experience (Part 3)

Used **Cursor Agent** in the IDE instead of GitHub Copilot via Issue (same intent: AI-assisted implementation and test generation). Prompts and iteration are logged in [`prompts-history.md`](prompts-history.md).

**What worked well:**
- End-to-end scaffolding (repository, service, controller, router, DI) from a single PLAN.md prompt
- Test cases covering happy path + error scenarios matched PLAN requirements quickly

**What required manual fixes:**
- Build/runtime: JDK 21, H2 1.4.200 vs Exposed compatibility, Gradle/Kotlin version bumps
- Test infra: shared DB leakage, Kodein singleton + schema init, port binding, Jackson deserialization for article JSON
- Exposed join/transaction issues in `ArticleRepository`

**How I'd improve the agent workflow for a customer:**
- Provide a short "test harness constraints" doc up front (DB isolation, port strategy, DTO shape)
- Run `./gradlew test` in-loop after each layer instead of one big implementation pass
- Keep a prompts/changelog file (like `prompts-history.md`) so review is auditable

## CI/CD (Part 4)

Updated [`.github/workflows/gradle.yml`](.github/workflows/gradle.yml):

- `./gradlew build` and `./gradlew test` on push/PR to `master`
- JDK **17** and **21** matrix
- Gradle dependency caching (`gradle-build-action@v3`)
- JUnit XML → GitHub check annotations (`dorny/test-reporter`)

Bonus: [`.github/workflows/spec-api.yml`](.github/workflows/spec-api.yml) runs `spec-api/run-api-tests.sh` against a live server.

Docs: [`testing.md`](testing.md) (CI overview + local spec-api steps), [`local-development-environment.md`](local-development-environment.md) (nix-shell, `JAVA_HOME`).

Also: `run-api-tests.sh` now requires `APIURL` (removed deprecated default cloud URL); `./run-api-tests.sh --help` for usage.

## Test plan

- [x] `./gradlew build test` passes locally
- [ ] `GET /articles/feed/popular` with valid JWT returns sorted articles
- [ ] Unauthenticated request returns 401
- [ ] Invalid `limit` / `offset` return 422
- [ ] GitHub Actions green on JDK 17 and 21
- [ ] (Optional) spec-api workflow runs; expect partial failures until more endpoints are implemented

## CI status

Pre-flight on fork PR #1: **CI with Gradle passed** on JDK 17 and JDK 21 (`./gradlew build` + `./gradlew test`).

### JUnit tests (`./gradlew test`)

- **`PopularArticleFeedControllerTest`** — runs in CI; covers popular feed (sort order, pagination, 401, 422).
- Legacy controller tests (`UserControllerTest`, `ArticleControllerTest`, etc.) remain **`@Ignore`** as in upstream — not part of this PR’s scope.

### Bonus: RealWorld spec-api workflow (`spec-api.yml`)

The Newman/Postman job starts **this branch’s server** on `http://localhost:8080` and runs `spec-api/run-api-tests.sh`. It **fails** because most RealWorld endpoints are still stubs in this codebase (only a subset is implemented, including the new popular feed).

This is **expected and intentional**:

- PLAN Part 4 lists spec-api as **(Bonus)** — wire up the workflow, not full API conformance.
- Workflow uses `continue-on-error: true` so it does **not** block merge.
- Full RealWorld compliance is out of scope for Option A.

**Gate for this PR:** green **CI with Gradle** matrix, not spec-api.